### PR TITLE
pinned gem versions (especially 'airplay')

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,20 @@
 source "https://rubygems.org"
 
-gem 'rake'
+gem 'rake', '~> 10.1.0'
 
-gem 'airplay'
-gem 'ruby-progressbar'
+gem 'airplay', '~> 0.2.9'
+gem 'ruby-progressbar', '~> 1.1.1'
 
-gem 'rack'
-gem 'webrick'
+gem 'rack', '~> 1.5.2'
+gem 'webrick', '~> 1.3.1'
 
 group :development do
   gem 'rake-notes'
 end
 
 group :test do
-  gem 'rake'
   gem 'minitest'
   gem 'coveralls', require: false
   gem 'oj'
   gem 'aruba'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,58 +12,64 @@ GEM
     builder (3.2.2)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
-    colorize (0.5.8)
-    coveralls (0.6.7)
-      colorize
+    colored (1.2)
+    coveralls (0.7.0)
       multi_json (~> 1.3)
       rest-client
       simplecov (>= 0.7)
+      term-ansicolor
       thor
-    cucumber (1.3.5)
+    cucumber (1.3.10)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12.0)
-      multi_json (~> 1.7.5)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.0.2)
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     dnssd (2.0)
-    ffi (1.9.0)
-    gherkin (2.12.0)
+    docile (1.1.1)
+    ffi (1.9.3)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
-    mime-types (1.23)
-    minitest (5.0.6)
-    multi_json (1.7.8)
+    mime-types (2.0)
+    minitest (5.2.0)
+    multi_json (1.8.2)
     multi_test (0.0.2)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9)
-    oj (2.1.4)
+    oj (2.5.1)
     rack (1.5.2)
-    rake (10.1.0)
-    rake-notes (0.0.1)
+    rake (10.1.1)
+    rake-notes (0.2.0)
+      colored
       rake
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rspec-expectations (2.14.0)
+    rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     ruby-progressbar (1.1.1)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    term-ansicolor (1.2.2)
+      tins (~> 0.8)
     thor (0.18.1)
+    tins (0.13.1)
     webrick (1.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  airplay
+  airplay (~> 0.2.9)
   aruba
   coveralls
   minitest
   oj
-  rack
-  rake
+  rack (~> 1.5.2)
+  rake (~> 10.1.0)
   rake-notes
-  ruby-progressbar
-  webrick
+  ruby-progressbar (~> 1.1.1)
+  webrick (~> 1.3.1)


### PR DESCRIPTION
The airstream used version 0.2.9 of the airplay gem. The recent update
of airplay to 1.X broke airstream. (see unused#16)
Pinned other gems as well, as this will prevent similar issues in the
future.
