### PR TITLE
added missing player file to gemspec

### DIFF
--- a/airstream.gemspec
+++ b/airstream.gemspec
@@ -19,6 +19,7 @@ lib/airstream/device.rb
 lib/airstream/io.rb
 lib/airstream/network.rb
 lib/airstream/node.rb
+lib/airstream/player.rb
 lib/airstream/version.rb
 lib/airstream/video.rb
 )


### PR DESCRIPTION
Added `lib/airstream/player.rb` to gemspec file, because otherwise:

```
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- airstream/player.rb (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /var/lib/gems/1.9.1/gems/airstream-0.4.2/lib/airstream.rb:17:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /var/lib/gems/1.9.1/gems/airstream-0.4.2/bin/airstream:6:in `<top (required)>'
    from /usr/local/bin/airstream:23:in `load'
    from /usr/local/bin/airstream:23:in `<main>'
```

BTW. The latest version on rubygems.org is still 0.3.7.  Did you push 0.4.X?
