### PR TITLE
Apple TV resolving and youtube-dl integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    airstream (0.4.8)
+    airstream (0.4.9)
       airplay (~> 0.2.9)
       rack (~> 1.5.2)
-      ruby-progressbar (~> 1.1.1)
+      ruby-progressbar (~> 1.7.5)
       webrick (~> 1.3.1)
 
 GEM
@@ -48,7 +48,7 @@ GEM
     net-http-persistent (2.9.4)
     netrc (0.10.3)
     oj (2.12.1)
-    rack (1.5.2)
+    rack (1.5.3)
     rake (10.4.2)
     rake-notes (0.2.0)
       colored
@@ -60,7 +60,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    ruby-progressbar (1.1.1)
+    ruby-progressbar (1.7.5)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,20 @@ but is planned to. Do not hesitate to send me any ideas or bug informations.
 ## Installation
 
 ```
-gem install airstream
+gem install specific_install
+gem specific_install michaelvillar/airstream
+brew install youtube-dl
 ```
 
 See **Troubleshooting** below, if you experience any problems while installing.
 
 ## Basic Usage
+
+Airstream automatically find your Apple TV on your local network.
+It also can play remote files, even from Youtube, Vimeo and others (don't forget to install youtube-dl -- see above).
+```shell
+airstream http://youtube.com/watch?v=gCluaJe3lb4
+```
 
 Use the output argument to specify the ip-address of the remote device. Remote
 files will be played directly, local files are hosted with a small webserver

--- a/airstream.gemspec
+++ b/airstream.gemspec
@@ -28,7 +28,7 @@ lib/airstream/video.rb
 
 
   s.add_dependency 'airplay', '~> 0.2.9'
-  s.add_dependency 'ruby-progressbar', '~> 1.1.1'
+  s.add_dependency 'ruby-progressbar', '~> 1.7.5'
   s.add_dependency 'rack', '~> 1.5.2'
   s.add_dependency 'webrick', '~> 1.3.1'
 

--- a/bin/airstream
+++ b/bin/airstream
@@ -126,7 +126,9 @@ def stream(receiver)
     begin # reconsider playing...
       sleep UPDATE_TIMEOUT
       formatted_time = Time.at(player.elapsed_time).gmtime.strftime('%R:%S')
-      pbar.title = "#{player.current_title} #{formatted_time}"
+      current_title = player.current_title.to_s
+      title = current_title[0..[30, current_title.length].min]
+      pbar.title = "#{title} #{formatted_time}"
       pbar.progress = player.elapsed_time
       io.catch_input
       player.update io

--- a/bin/airstream
+++ b/bin/airstream
@@ -9,6 +9,21 @@ def self.exit(status)
   super status
 end
 
+def parse_time(time)
+  res = time.match("([0-9]*)m(?:i?n?u?t?e?s?)?(?: ?([0-9]*)s(?:e?c?o?n?d?s?)?)?")
+  if res.nil?
+    res = time.match("([0-9]*):([0-9]*)")
+  end
+  unless res.nil?
+    seconds = res[1].to_i * 60
+    unless res[2].nil?
+      seconds += res[2].to_i
+    end
+    return seconds
+  end
+  time.to_i
+end
+
 $options = options = {
   receiver: nil,
   quiet: false,
@@ -48,8 +63,8 @@ Basic options: (configure default in ~/.airstreamrc)
   end
 
   opts.on("-t time",
-    "jump to a specific time in seconds") do |time|
-    options[:time] = time
+    "jump to a specific time in seconds or in minutes (i.e. 10m 30s)") do |time|
+    options[:time] = parse_time(time)
   end
 
   opts.on("-q","--quiet",
@@ -102,7 +117,7 @@ def stream(receiver)
     playlist.map! { |file| Airstream::Video.new(file) }
     player = Airstream::Player.new device, playlist
     if options[:time]
-      player.seek(options[:time].to_i)
+      player.seek(options[:time])
     end
 
     io.puts "=> press ["+Airstream::Io::KEY_QUIT+"] to exit airstream"

--- a/bin/airstream
+++ b/bin/airstream
@@ -10,7 +10,7 @@ def self.exit(status)
 end
 
 def parse_time(time)
-  res = time.match("([0-9]*)m(?:i?n?u?t?e?s?)?(?: ?([0-9]*)s(?:e?c?o?n?d?s?)?)?")
+  res = time.match("([0-9]*)m(?:i?n?u?t?e?s?)?(?:([0-9]*)s(?:e?c?o?n?d?s?)?)?")
   if res.nil?
     res = time.match("([0-9]*):([0-9]*)")
   end
@@ -63,7 +63,7 @@ Basic options: (configure default in ~/.airstreamrc)
   end
 
   opts.on("-t time",
-    "jump to a specific time in seconds or in minutes (i.e. 10m 30s)") do |time|
+    "jump to a specific time in seconds or in minutes (i.e. 10m30s)") do |time|
     options[:time] = parse_time(time)
   end
 

--- a/bin/airstream
+++ b/bin/airstream
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'airstream'
+require 'dnssd'
 
 def self.exit(status)
   Airstream::Io.show_input
@@ -8,8 +9,8 @@ def self.exit(status)
   super status
 end
 
-options = {
-  reciever: '192.168.0.123',
+$options = options = {
+  receiver: nil,
   quiet: false,
   verbose: false,
   # disable_local_http: true
@@ -40,9 +41,9 @@ Usage: #{executable_name} [options] [url|path/]filename
 Basic options: (configure default in ~/.airstreamrc)
 "
 
-  opts.on("-o RECIEVER",
-   "the airplay-device ip-address or domain") do |reciever|
-    options[:reciever] = reciever
+  opts.on("-o receiver",
+   "the airplay-device ip-address or domain") do |receiver|
+    options[:receiver] = receiver
   end
 
   opts.on("-q","--quiet",
@@ -72,58 +73,84 @@ if ARGV.empty?
   STDERR.puts option_parser
   exit EXIT_ERROR
 end
-playlist = ARGV
+
 
 begin
-
   option_parser.parse!
-
-  unless options[:reciever]
-    STDERR.puts "No host given"
-    exit EXIT_NO_HOST
-  end
-
-  io = Airstream::Io.new
-  io.quiet = options[:quiet]
-  io.verbose = options[:verbose]
-  node = Airstream::Node.new options[:reciever]
-  device = Airstream::Device.new node
-  io.puts "loading can take a few seconds..."
-  playlist.map! { |file| Airstream::Video.new(file) }
-  player = Airstream::Player.new device, playlist
-
-  io.puts "=> press ["+Airstream::Io::KEY_QUIT+"] to exit airstream"
-  Airstream::Io.hide_input
-  pbar = ProgressBar.create({ format: '%t |%b%i| %p%%', total: player.duration })
-  begin # reconsider playing...
-    sleep UPDATE_TIMEOUT
-    formatted_time = Time.at(player.elapsed_time).gmtime.strftime('%R:%S')
-    pbar.title = "#{player.current_title} #{formatted_time}"
-    pbar.progress = player.elapsed_time
-    io.catch_input
-    player.update io
-  end until io.quit? || player.finished?
-  pbar.finish
-
-rescue Airplay::Protocol::InvalidMediaError
-  STDERR.puts
-  STDERR.puts "invalid media file"
-  exit EXIT_ERROR
-# rescue NoMethodError # @FIX webrick raises no method error
-#   STDERR.puts
-#   STDERR.puts "file host shutdown"
-#   exit EXIT_OK
-rescue Interrupt
-  STDERR.puts
-  STDERR.puts "exiting"
-  exit EXIT_ERROR
 rescue OptionParser::InvalidArgument => ex
   STDERR.puts ex.message
   STDERR.puts option_parser
   exit EXIT_ERROR
-ensure
-  Airstream::Io.show_input
+end
+
+def stream(receiver)
+  begin
+    options = $options
+    playlist = ARGV
+    io = Airstream::Io.new
+    io.quiet = options[:quiet]
+    io.verbose = options[:verbose]
+    node = Airstream::Node.new receiver
+    device = Airstream::Device.new node
+    io.puts "loading can take a few seconds..."
+    playlist.map! { |file| Airstream::Video.new(file) }
+    player = Airstream::Player.new device, playlist
+
+    io.puts "=> press ["+Airstream::Io::KEY_QUIT+"] to exit airstream"
+    Airstream::Io.hide_input
+    pbar = ProgressBar.create({ format: '%t |%b%i| %p%%', total: player.duration })
+    begin # reconsider playing...
+      sleep UPDATE_TIMEOUT
+      formatted_time = Time.at(player.elapsed_time).gmtime.strftime('%R:%S')
+      pbar.title = "#{player.current_title} #{formatted_time}"
+      pbar.progress = player.elapsed_time
+      io.catch_input
+      player.update io
+    end until io.quit? || player.finished?
+    pbar.finish
+
+  rescue Airplay::Protocol::InvalidMediaError
+    STDERR.puts
+    STDERR.puts "invalid media file"
+    exit EXIT_ERROR
+  # rescue NoMethodError # @FIX webrick raises no method error
+  #   STDERR.puts
+  #   STDERR.puts "file host shutdown"
+  #   exit EXIT_OK
+  rescue Interrupt
+    STDERR.puts
+    STDERR.puts "exiting"
+    exit EXIT_ERROR
+  ensure
+    Airstream::Io.show_input
+  end
+end
+
+unless options[:receiver]
+  wait = 10
+
+  DNSSD.browse '_airplay._tcp' do |reply|
+    resolve(reply.name)
+  end
+
+  def resolve(name)
+    DNSSD.resolve name, '_airplay._tcp', 'local' do |reply|
+      if reply.text_record["model"].match(/AppleTV/)
+        DNSSD::Service.new.getaddrinfo(reply.target, 1) do |addr|
+          puts "Apple TV: #{reply.target} (#{addr.address})"
+          wait = 0
+          stream(addr.address)
+        end
+      end
+    end
+  end
+  # STDERR.puts "No host given"
+  # exit EXIT_NO_HOST
+  while wait > 0 do
+    sleep(1)
+  end
+else
+  stream(options[:receiver])
 end
 
 exit EXIT_OK
-

--- a/bin/airstream
+++ b/bin/airstream
@@ -151,27 +151,28 @@ def stream(receiver)
 end
 
 unless options[:receiver]
-  wait = 10
+  wait = 0
+  apple_tv_found = false
 
   DNSSD.browse '_airplay._tcp' do |reply|
-    resolve(reply.name)
-  end
-
-  def resolve(name)
-    DNSSD.resolve name, '_airplay._tcp', 'local' do |reply|
+    DNSSD.resolve reply.name, '_airplay._tcp', 'local' do |reply|
       if reply.text_record["model"].match(/AppleTV/)
         DNSSD::Service.new.getaddrinfo(reply.target, 1) do |addr|
           puts "Apple TV: #{reply.target} (#{addr.address})"
-          wait = 0
+          apple_tv_found = true
           stream(addr.address)
         end
       end
     end
   end
-  # STDERR.puts "No host given"
-  # exit EXIT_NO_HOST
-  while wait > 0 do
+
+  while true do
     sleep(1)
+    wait += 1
+    if wait > 5 and !apple_tv_found
+      STDERR.puts "Couldn't find Apple TV"
+      exit EXIT_NO_HOST
+    end
   end
 else
   stream(options[:receiver])

--- a/bin/airstream
+++ b/bin/airstream
@@ -13,6 +13,7 @@ $options = options = {
   receiver: nil,
   quiet: false,
   verbose: false,
+  time: nil,
   # disable_local_http: true
 }
 
@@ -44,6 +45,11 @@ Basic options: (configure default in ~/.airstreamrc)
   opts.on("-o receiver",
    "the airplay-device ip-address or domain") do |receiver|
     options[:receiver] = receiver
+  end
+
+  opts.on("-t time",
+    "jump to a specific time in seconds") do |time|
+    options[:time] = time
   end
 
   opts.on("-q","--quiet",
@@ -95,6 +101,9 @@ def stream(receiver)
     io.puts "loading can take a few seconds..."
     playlist.map! { |file| Airstream::Video.new(file) }
     player = Airstream::Player.new device, playlist
+    if options[:time]
+      player.seek(options[:time].to_i)
+    end
 
     io.puts "=> press ["+Airstream::Io::KEY_QUIT+"] to exit airstream"
     Airstream::Io.hide_input

--- a/lib/airstream/video.rb
+++ b/lib/airstream/video.rb
@@ -1,6 +1,7 @@
 
 require 'rack'
 require 'webrick'
+require 'open3'
 
 module Airstream
   class Video
@@ -8,7 +9,17 @@ module Airstream
     @@server = nil
 
     def initialize(video_file)
-      @filename = video_file
+      begin
+        stdin, stdout, stderr = Open3.popen3("youtube-dl -f best -g #{video_file}")
+        output = stdout.gets
+        if stderr.gets.nil? && !output.nil?
+          @filename = output
+        else
+          @filename = video_file
+        end
+      rescue Exception => e
+        @filename = video_file
+      end
     end
 
     def to_s


### PR DESCRIPTION
This is a late-night hack that gives these two features:
- Apple TV IP auto resolving: no need to give the receiver param anymore
- youtube-dl integration: directly play a youtube, vimeo,... video

This is a pretty bad code but it gives the idea.