### PR TITLE
Adding FreeBSD "dns_sd.h not found" solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ For Ubuntu/Debian:
 sudo apt-get install libavahi-compat-libdnssd-dev
 ```
 
+For FreeBSD:
+
+```
+sudo pkg install avahi-libdns
+gem install airstream -- --with-dnssd-lib=/usr/local/lib/ --with-dnssd-include=/usr/local/include/avahi-compat-libdns_sd/
+```
 
 ## History
 


### PR DESCRIPTION
Hello,

I added instruction about how to fix the dns_sd.h error in FreeBSD.

Best Regards,
Stefan